### PR TITLE
Added homepage menu

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -2,28 +2,26 @@ import Image from "next/image";
 
 const Footer = () => {
     return (
-        <header>
-            <nav className="sticky bottom-0 left-0 w-full pb-4 mt-20">
-                <div className="flex flex-row items-center mb-4">
-                    <div className="flex ml-6 md:mr-20 md:mr-0 text-gray-500 text-md md:text-lg whitespace-nowrap">
-                        © 2022 D_Agency
-                    </div>
-                    <div className="flex justify-end flex-grow items-center ml-16 mr-6 mt-2 gap-8">
-                        <a
-                            href="#"><Image src={"/discord-icon.svg"} alt="Discord logo" width={30} height={30}></Image>
-                        </a>
-                        <a
-                            href="#">
-                            <Image src={"/twitter-icon.svg"} alt="Twitter logo" width={30} height={30}></Image>
-                        </a>
-                        <a
-                            href="#">
-                            <Image src={"/instagram-icon.svg"} alt="Instagram logo" width={30} height={30}></Image>
-                        </a>
-                    </div>
+        <nav className="sticky bottom-0 left-0 w-full pb-4">
+            <div className="flex flex-row items-center mb-4">
+                <div className="flex ml-6 md:mr-20 md:mr-0 text-gray-500 text-md md:text-lg whitespace-nowrap">
+                    © 2022 D_Agency
                 </div>
-            </nav>
-        </header>
+                <div className="flex justify-end flex-grow items-center ml-16 mr-6 mt-2 gap-8">
+                    <a
+                        href="#"><Image src={"/discord-icon.svg"} alt="Discord logo" width={30} height={30}></Image>
+                    </a>
+                    <a
+                        href="#">
+                        <Image src={"/twitter-icon.svg"} alt="Twitter logo" width={30} height={30}></Image>
+                    </a>
+                    <a
+                        href="#">
+                        <Image src={"/instagram-icon.svg"} alt="Instagram logo" width={30} height={30}></Image>
+                    </a>
+                </div>
+            </div>
+        </nav>
     )
 }
 

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,6 +1,10 @@
 import Image from "next/image";
+import {useContext} from "react";
+import {MenuContext} from "../pages";
 
 const Header = () => {
+    const {isOpen, setOpen} = useContext(MenuContext);
+
     return (
         <header>
             <nav className="flex justify-between w-full top-0 pt-8 pb-8">
@@ -10,18 +14,23 @@ const Header = () => {
                 <div className="flex justify-end flex-grow lg:items-center mr-3">
                     <ul className="flex justify-end items-center">
                         <li className="md:mr-3">
-                            <a className="inline-block border-white border-solid border p-1.5 md:p-3 mr-4 whitespace-nowrap text-xxs md:text-sm md:text-lg text-white px-4"
-                               href="#">WORK WITH US</a>
+                            {
+                                !isOpen &&
+                                <a className="inline-block border-white border-solid border p-1.5 md:p-3 mr-4 whitespace-nowrap text-xxs md:text-sm md:text-lg text-white px-4"
+                                   href="#">WORK WITH US</a>
+                            }
                         </li>
                         <li className="mr-4">
-                            <a className="inline-block"
-                               href="#">
-                                <div className="space-y-1">
-                                    <div className="w-5 md:w-8 h-0.5 bg-white"></div>
-                                    <div className="w-5 md:w-8 h-0.5 bg-white"></div>
-                                    <div className="w-5 md:w-8 h-0.5 bg-white"></div>
-                                </div>
-                            </a>
+                            <button onClick={() => setOpen(!isOpen)} className="space-y-1">
+                                {!isOpen && <div className="w-5 md:w-8 h-0.5 bg-white"></div>}
+                                {!isOpen && <div className="w-5 md:w-8 h-0.5 bg-white"></div>}
+                                {!isOpen && <div className="w-5 md:w-8 h-0.5 bg-white"></div>}
+                                {isOpen &&
+                                    <Image src={"/x-icon.svg"} alt="Developer DAO agency logo" width={30}
+                                           height={30}></Image>
+                                }
+
+                            </button>
                         </li>
                     </ul>
                 </div>

--- a/components/HomepageMenu.jsx
+++ b/components/HomepageMenu.jsx
@@ -1,0 +1,15 @@
+const HomepageMenu = () => {
+    return (
+        <div className="flex justify-center md:justify-start md:ml-40 h-screen">
+            <ul className="flex flex-col text-4xl md:text-6xl gap-y-16 my-auto">
+                <li className="hover:underline">ABOUT</li>
+                <li className="hover:underline">PROJECTS</li>
+                <li className="hover:underline">CONTACT</li>
+                <li className="hover:underline">WORK WITH US</li>
+            </ul>
+        </div>
+
+    )
+}
+
+export default HomepageMenu;

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,8 +3,14 @@ import Header from "../components/Header";
 import Footer from "../components/Footer";
 import Body from "../components/Body";
 import Image from "next/image";
+import {createContext, useState} from "react";
+import HomepageMenu from "../components/HomepageMenu";
+
+export const MenuContext = createContext(null);
 
 export default function Home() {
+    const [isOpen, setOpen] = useState(false);
+
     return (
         <div className="text-white">
             <Head>
@@ -12,31 +18,41 @@ export default function Home() {
                 <meta name="description" content="Developer DAO's Agency"/>
                 <link rel="icon" href="/favicon.ico"/>
             </Head>
-            <Header/>
+            <MenuContext.Provider value={{isOpen, setOpen}}>
+                <Header/>
+            </MenuContext.Provider>
             <main>
-                <div className="flex m-16 lg:pr-128 md:m-28 text-sm md:text-lg">
-                    <Body headlineText="WHO WE ARE"
-                          bodyText={<div>D_Agency is a collective venture builder curated from the best talent within <a
-                              className="underline">DeveloperDAO</a>. By bringing
-                              together the best developers, designers and project managers, we aim to collectively build
-                              products and
-                              services for our clients and the web3 space.</div>} bottomText={<a
-                        href="#">Find out more about us</a>}/>
-                </div>
-                <div className="relative w-full h-40 md:h-96 lg:h-128 mb-20">
-                    <Image src={"/person-writing.png"} alt="Person writing" layout="fill"/>
-                </div>
-                <div className="flex m-8 md:m-28 lg:m-32">
-                    <div className="relative w-[60rem] md:w-[80rem] h-72 md:h-96 lg:h-128">
-                        <Image src={"/computer-screen.png"} alt="Computer screen" layout="fill"/>
+                {isOpen && <HomepageMenu/>}
+                {!isOpen &&
+                    <div>
+                        <div className="flex m-16 lg:pr-128 md:m-28 text-sm md:text-lg">
+                            <Body headlineText="WHO WE ARE"
+                                  bodyText={<div>D_Agency is a collective venture builder curated from the best talent
+                                      within <a
+                                          className="underline">DeveloperDAO</a>. By bringing
+                                      together the best developers, designers and project managers, we aim to
+                                      collectively
+                                      build
+                                      products and
+                                      services for our clients and the web3 space.</div>} bottomText={<a
+                                href="#">Find out more about us</a>}/>
+                        </div>
+                        <div className="relative w-full h-40 md:h-96 lg:h-128 mb-20">
+                            <Image src={"/person-writing.png"} alt="Person writing" layout="fill"/>
+                        </div>
+                        <div className="flex m-8 md:m-28 lg:m-32">
+                            <div className="relative w-[60rem] md:w-[80rem] h-72 md:h-96 lg:h-128">
+                                <Image src={"/computer-screen.png"} alt="Computer screen" layout="fill"/>
+                            </div>
+                            <div className="flex ml-4 md:m-14 lg:m-32 text-sm md:text-lg">
+                                <Body headlineText="HOW CAN WE HELP YOU?"
+                                      bodyText="Our teams are diverse, coming from a range of backgrounds and specialisations. These teams are hand picked from the best that Developer DAO has to offer to meet your project needs."
+                                      bottomText={<a
+                                          href="#">Find out more about our services</a>}/>
+                            </div>
+                        </div>
                     </div>
-                    <div className="flex ml-4 md:m-14 lg:m-32 text-sm md:text-lg">
-                        <Body headlineText="HOW CAN WE HELP YOU?"
-                              bodyText="Our teams are diverse, coming from a range of backgrounds and specialisations. These teams are hand picked from the best that Developer DAO has to offer to meet your project needs."
-                              bottomText={<a
-                                  href="#">Find out more about our services</a>}/>
-                    </div>
-                </div>
+                }
             </main>
             <footer>
                 <Footer/>

--- a/public/x-icon.svg
+++ b/public/x-icon.svg
@@ -1,0 +1,4 @@
+<svg width="34" height="35" viewBox="0 0 34 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3.00024" y="1" width="43" height="3.70588" transform="rotate(45 3.00024 1)" fill="white"/>
+<rect x="0.00012207" y="31" width="43" height="3.70588" transform="rotate(-45 0.00012207 31)" fill="white"/>
+</svg>


### PR DESCRIPTION
• Added homepage menu w/context used to manage open and close of replacing homepage content 

Desktop

Image 1: 

<img width="1572" alt="desktop view 1" src="https://user-images.githubusercontent.com/47253537/186220567-d27165d6-0a0e-4913-ba55-e0f62b601305.png">

Image 2: 

<img width="1565" alt="desktop view 2" src="https://user-images.githubusercontent.com/47253537/186220600-f666f818-b051-4f74-86bb-2effa2391840.png">

Mobile 1: 

<img width="661" alt="mobile view" src="https://user-images.githubusercontent.com/47253537/186220645-9e01b8d8-4955-41d0-a872-29c2960024e1.png">

Mobile 2: 

<img width="791" alt="mobile 2" src="https://user-images.githubusercontent.com/47253537/186220687-1660ae4f-07f9-47ca-b646-f14eb05c067f.png">

Responsive:

https://user-images.githubusercontent.com/47253537/186220758-c1b45698-cfe4-4a48-8be4-dc37cf9b2d42.mov



